### PR TITLE
chore: add default public project env id [DEV-165]

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@dynamic-labs/client";
 import { ReactNativeExtension } from "@dynamic-labs/react-native-extension";
 
-const environmentId = process.env.EXPO_PUBLIC_ENVIRONMENT_ID as string;
+const environmentId = process.env.EXPO_PUBLIC_ENVIRONMENT_ID as string || '2762a57b-faa4-41ce-9f16-abff9300e2c9';
 
 if (!environmentId) {
   throw new Error("EXPO_PUBLIC_ENVIRONMENT_ID is required");


### PR DESCRIPTION
We have a default public project so that people can try sample apps without needing an account yet. This PR adds that environment if the env variable is not set.